### PR TITLE
Add check for empty series in getAxis function

### DIFF
--- a/packages/solid-charts/src/components/Chart.tsx
+++ b/packages/solid-charts/src/components/Chart.tsx
@@ -309,7 +309,7 @@ const Chart = (props: ChartProps) => {
         getAxis: (axisId) => {
           const axis = axes().get(axisId)
           // Fallback while rendering. Maybe there is a better solution for this?
-          if (!axis) {
+          if (!axis || axis.series.size === 0) {
             return {
               min: 0,
               max: 0,


### PR DESCRIPTION
<Chart> component throws on empty 'data'
to reproduce the error: <Chart data={[]}>...</Chart>